### PR TITLE
Fall back to en if locale is not supported

### DIFF
--- a/custom_components/fronius_local/api.py
+++ b/custom_components/fronius_local/api.py
@@ -61,8 +61,10 @@ class FroniusApiClient:
             self.trans = {}
 
         if self.trans.get(lang) is None:
+            if lang not in fl.SUPPORTED_LOCALES:
+                lang = "en"
             self.trans[lang] = await self.get(
-                "http://192.168.0.42/app/assets/i18n/WeblateTranslations/config/"
+                "/app/assets/i18n/WeblateTranslations/config/"
                 + lang
                 + ".json"
             )

--- a/custom_components/fronius_local/const.py
+++ b/custom_components/fronius_local/const.py
@@ -11,6 +11,8 @@ LOGGER: logging.Logger = logging.getLogger(DOMAIN)
 
 UPDATE_INTERVAL = 9
 
+SUPPORTED_LOCALES = ["en", "de", "es", "fr", "it", "hu", "pl", "pt", "ru", "uk"]
+
 FILTER = [
     "PV_PEAK_POWER",
     "supportSoc",


### PR DESCRIPTION
Currently, if the locale set in hass is not supported in the fronius device, the integration won't start. This makes the integration fall back to english in such cases.